### PR TITLE
feat[task-23]: add sign in flow with validation and error handling

### DIFF
--- a/src/components/Login/Login.component.tsx
+++ b/src/components/Login/Login.component.tsx
@@ -1,34 +1,90 @@
 import { Box, Stack } from '@mui/material';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { localizationContext } from '../../context/localizationContext';
 import { AuthDialog } from '../../shared/AuthDialog';
 import { Button } from '../../shared/Button';
 import { Input } from '../../shared/Input';
+import { useNavigate } from 'react-router-dom';
+import { useSignInWithEmailAndPassword } from 'react-firebase-hooks/auth';
+import { Spinner } from '../../shared/Spinner';
+import { ErrorSnackbar } from '../../shared/ErrorSnackbar';
+import { auth } from '../../firebase';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import loginFormSchema from '../../validationSchemas/loginFormSchema';
+
+export type LoginFormFields = {
+  email: string;
+  password: string;
+};
 
 const Login = () => {
+  const [signInWithEmailAndPassword, user, loading, error] =
+    useSignInWithEmailAndPassword(auth);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (user) {
+      navigate('/main');
+    }
+  }, [user]);
+
   const {
     currentLocalization: {
       loginPage: { title, email, password, submit },
     },
   } = useContext(localizationContext);
 
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<LoginFormFields>({
+    mode: 'onChange',
+    resolver: yupResolver(loginFormSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  });
+
+  const onSubmitHandler: SubmitHandler<LoginFormFields> = (
+    data: LoginFormFields,
+  ): void => {
+    signInWithEmailAndPassword(data.email, data.password);
+  };
+
   return (
-    <AuthDialog title={title}>
-      <Box component="form">
-        <Stack gap={4}>
-          <Input placeholder={email} variant="outlined" icon="email" />
-          <Input
-            placeholder={password}
-            variant="outlined"
-            type="password"
-            icon="pass"
-          />
-        </Stack>
-        <Button type="submit" variant="contained">
-          {submit}
-        </Button>
-      </Box>
-    </AuthDialog>
+    <>
+      <AuthDialog title={title}>
+        <Box component="form" onSubmit={handleSubmit(onSubmitHandler)}>
+          <Stack gap={4}>
+            <Input
+              placeholder={email}
+              autoComplete="new-password"
+              icon="email"
+              {...register('email')}
+              error={Boolean(errors.email)}
+              helperText={errors.email?.message ?? '\u00A0'}
+            />
+            <Input
+              placeholder={password}
+              type="password"
+              autoComplete="new-password"
+              icon="pass"
+              {...register('password')}
+              error={Boolean(errors.password)}
+              helperText={errors.password?.message ?? '\u00A0'}
+            />
+          </Stack>
+          <Button type="submit" variant="contained" disabled={!isValid}>
+            {submit}
+          </Button>
+        </Box>
+      </AuthDialog>
+      <Spinner open={loading} />
+      <ErrorSnackbar open={Boolean(error)} message={error?.message} />
+    </>
   );
 };
 

--- a/src/components/Registration/Registration.component.tsx
+++ b/src/components/Registration/Registration.component.tsx
@@ -72,7 +72,6 @@ const Registration = () => {
           <Stack gap={3}>
             <Input
               placeholder={name}
-              variant="outlined"
               icon="user"
               {...register('name')}
               error={Boolean(errors.name)}
@@ -80,7 +79,6 @@ const Registration = () => {
             />
             <Input
               placeholder={email}
-              variant="outlined"
               icon="email"
               {...register('email')}
               error={Boolean(errors.email)}
@@ -88,7 +86,6 @@ const Registration = () => {
             />
             <Input
               placeholder={password}
-              variant="outlined"
               type="password"
               icon="pass"
               {...register('password')}
@@ -97,7 +94,6 @@ const Registration = () => {
             />
             <Input
               placeholder={passwordRepeat}
-              variant="outlined"
               type="password"
               icon="pass"
               {...register('passwordConfirm')}
@@ -110,7 +106,7 @@ const Registration = () => {
           </Button>
         </Box>
       </AuthDialog>
-      <Spinner open={Boolean(loading)} />
+      <Spinner open={loading} />
       <ErrorSnackbar open={Boolean(error)} message={error?.message} />
     </>
   );

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,11 +1,5 @@
 import { FirebaseApp, initializeApp } from 'firebase/app';
-import {
-  getAuth,
-  signInWithEmailAndPassword,
-  signOut,
-  Auth,
-  UserCredential,
-} from 'firebase/auth';
+import { getAuth, signOut, Auth, UserCredential } from 'firebase/auth';
 import {
   getFirestore,
   collection,
@@ -27,17 +21,6 @@ const firebaseConfig: Record<string, string> = {
 const app: FirebaseApp = initializeApp(firebaseConfig);
 export const auth: Auth = getAuth(app);
 export const db: Firestore = getFirestore(app);
-
-export const logInWithEmailAndPassword = async (
-  email: string,
-  password: string,
-) => {
-  try {
-    await signInWithEmailAndPassword(auth, email, password);
-  } catch (err) {
-    console.error(err);
-  }
-};
 
 export type RegisterCallback = (
   name: string,

--- a/src/shared/Input/Input.component.tsx
+++ b/src/shared/Input/Input.component.tsx
@@ -24,6 +24,7 @@ const TextFieldWithAdornment = forwardRef(
     const svgIcon: JSX.Element = iconToSVGMap[icon];
     return (
       <TextField
+        variant="outlined"
         InputProps={{
           startAdornment: (
             <InputAdornment position="start">{svgIcon}</InputAdornment>

--- a/src/validationSchemas/loginFormSchema.ts
+++ b/src/validationSchemas/loginFormSchema.ts
@@ -1,0 +1,9 @@
+import * as yup from 'yup';
+import { LoginFormFields } from '../components/Login';
+
+const loginFormSchema: yup.ObjectSchema<LoginFormFields> = yup.object().shape({
+  email: yup.string().required('Email is required').email(),
+  password: yup.string().required('Password is required'),
+});
+
+export default loginFormSchema;


### PR DESCRIPTION
Ticket link: [[task-23]](https://github.com/ElizavetaRazumenko/graphiql-app/issues/23)
Description: add sign in flow with validation and error handling
Screenshots:
![image](https://github.com/ElizavetaRazumenko/graphiql-app/assets/41780056/c38e7064-30d6-4962-9406-0c250c9323b3)

![image](https://github.com/ElizavetaRazumenko/graphiql-app/assets/41780056/aaeaff86-ba11-4dff-b56a-acdefd15f86f)


Affected area: authentication
